### PR TITLE
Add founder bio to website

### DIFF
--- a/about.html
+++ b/about.html
@@ -43,8 +43,10 @@
         <section class="team">
             <div class="container">
                 <h2>Meet the Team</h2>
-<!-- Placeholder for team member bios -->
-                <p>[Team bios coming soon]</p>
+                <div class="team-member">
+                    <h3>Shawn Learn – Founder &amp; Chief Technology Officer</h3>
+                    <p>Shawn Learn blends expertise in kinesiology, engineering, and software systems gained from over two decades in mission‑critical roles. With degrees in both fields, he has studied human performance and built rigorous real-time platforms. For more than 18 years, Shawn specialized in hydraulic modeling and pipeline leak detection as a Senior Leak Detection Engineer at South Bow. At Precise Ventures he channels that interdisciplinary background into reliable fitness‑technology solutions that help users train smarter and safer.</p>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add founder biography to the About page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839dca5f38832db94fc6b9eae6e5c7