### PR TITLE
Update website timeline section

### DIFF
--- a/about.html
+++ b/about.html
@@ -50,11 +50,44 @@
             </div>
         </section>
 
-        <section class="roadmap">
-            <div class="container">
-                <h2>Roadmap</h2>
-                <p>[Development timeline placeholder]</p>
-            </div>
+        <section id="timeline" style="background:#FAFAFA; padding:80px 24px;">
+          <div style="max-width: 1000px; margin: 0 auto;">
+            <h2 style="font-family:'Montserrat',sans-serif; color:#2D2D2D; font-size:2rem; margin-bottom:40px; text-align:center;">Development Timeline</h2>
+            <ul style="list-style:none; padding:0; margin:0;">
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q1 2025</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Project inception, planning, and research</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q2 2025</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Core architecture design and prototyping</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q3 2025</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Initial backend, workout template system, and internal testing</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q4 2025</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">First private alpha version of Organizer</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q1 2026</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Web-based tracking interface and coach features</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q2 2026</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Mobile interface design, real-time logging, milestone tracking</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q3 2026</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Public beta release and integration with Garmin/Strava</p>
+              </li>
+              <li style="margin-bottom:40px;">
+                <h3 style="margin:0; color:#2F80ED;">Q4 2026</h3>
+                <p style="margin:4px 0 0; color:#4F4F4F;">Official product launch with pricing tiers and coach access tools</p>
+              </li>
+            </ul>
+          </div>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- replace development timeline placeholder on the About page with real dates for 2025–2026

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68841502fe04832db222693fa07a2349