### PR TITLE
Add SEO meta tags

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Learn about Precise Ventures and our mission to empower athletes and coaches with intelligent training tools.">
+    <meta property="og:title" content="About - Precise Ventures">
+    <meta property="og:description" content="Learn about Precise Ventures and our mission to empower athletes and coaches with intelligent training tools.">
+    <meta name="twitter:card" content="summary">
     <title>About - Precise Ventures</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Get in touch with Precise Ventures. We'd love to hear your questions or feedback about our fitness technology.">
+    <meta property="og:title" content="Contact - Precise Ventures">
+    <meta property="og:description" content="Get in touch with Precise Ventures. We'd love to hear your questions or feedback about our fitness technology.">
+    <meta name="twitter:card" content="summary">
     <title>Contact - Precise Ventures</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Precise Ventures builds tools that clarify training data. Organizer helps athletes and coaches streamline workouts.">
+    <meta property="og:title" content="Precise Ventures | Fitness Coaching Reimagined">
+    <meta property="og:description" content="Precise Ventures builds tools that clarify training data. Organizer helps athletes and coaches streamline workouts.">
+    <meta name="twitter:card" content="summary">
     <title>Precise Ventures | Fitness Coaching Reimagined</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Read how Precise Ventures collects, uses, and protects your personal information.">
+    <meta property="og:title" content="Privacy Policy - Precise Ventures">
+    <meta property="og:description" content="Read how Precise Ventures collects, uses, and protects your personal information.">
+    <meta name="twitter:card" content="summary">
     <title>Privacy Policy - Precise Ventures</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">

--- a/product.html
+++ b/product.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Discover Organizer, the flexible fitness tracking and coaching platform from Precise Ventures.">
+    <meta property="og:title" content="Organizer - Precise Ventures">
+    <meta property="og:description" content="Discover Organizer, the flexible fitness tracking and coaching platform from Precise Ventures.">
+    <meta name="twitter:card" content="summary">
     <title>Organizer - Precise Ventures</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">

--- a/terms.html
+++ b/terms.html
@@ -4,6 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Understand the terms and conditions for using Precise Ventures products and services.">
+    <meta property="og:title" content="Terms of Service - Precise Ventures">
+    <meta property="og:description" content="Understand the terms and conditions for using Precise Ventures products and services.">
+    <meta name="twitter:card" content="summary">
     <title>Terms of Service - Precise Ventures</title>
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- improve SEO for all site pages with description, Open Graph and Twitter metadata

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884158e10c8832d96a2d7cb5d47521e